### PR TITLE
Implement priority property in TorrentFileInfo and add read-only dire…

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,15 @@
+# Claude Code Configuration
+
+This directory contains configuration files for Claude Code to understand project-specific rules and constraints.
+
+## config.json
+
+Defines read-only directories and other project rules that Claude should follow when working with this codebase.
+
+### Read-Only Directories
+
+The following directories are marked as read-only and should **never** be modified:
+
+- `packages/legacy-jstorrent-engine` - Legacy code that must remain unchanged
+
+Claude can read, search, and analyze these directories but should never write, edit, or delete files within them.

--- a/.claude/config.json
+++ b/.claude/config.json
@@ -1,0 +1,14 @@
+{
+  "readOnlyDirectories": [
+    "packages/legacy-jstorrent-engine"
+  ],
+  "rules": {
+    "packages/legacy-jstorrent-engine": {
+      "readOnly": true,
+      "reason": "Legacy code that should not be modified. This is the original JSTorrent engine and should remain unchanged.",
+      "allowedOperations": ["read", "grep", "glob"],
+      "blockedOperations": ["write", "edit", "delete"]
+    }
+  },
+  "notes": "This configuration file tells Claude Code which directories are read-only and should never be modified."
+}

--- a/packages/engine/src/core/torrent-file-info.ts
+++ b/packages/engine/src/core/torrent-file-info.ts
@@ -2,6 +2,8 @@ import { TorrentFile } from './torrent-file'
 import { PieceManager } from './piece-manager'
 
 export class TorrentFileInfo {
+  private _priority: number = 2 // Default to normal priority (0=skip, 1=low, 2=normal, 3=high)
+
   constructor(
     private file: TorrentFile,
     private pieceManager: PieceManager,
@@ -58,6 +60,11 @@ export class TorrentFileInfo {
   }
 
   get priority(): number {
-    return 0 // TODO: Implement priority
+    return this._priority
+  }
+
+  set priority(value: number) {
+    // Clamp priority to valid range: 0 (skip) to 3 (high)
+    this._priority = Math.max(0, Math.min(3, Math.floor(value)))
   }
 }

--- a/packages/legacy-jstorrent-engine/DO_NOT_EDIT.md
+++ b/packages/legacy-jstorrent-engine/DO_NOT_EDIT.md
@@ -1,0 +1,22 @@
+# ⚠️ READ-ONLY DIRECTORY ⚠️
+
+**DO NOT MODIFY ANY FILES IN THIS DIRECTORY**
+
+This is the legacy JSTorrent engine code and must remain unchanged.
+
+## For Claude Code
+
+This directory is marked as **read-only**. You may:
+- ✅ Read files
+- ✅ Search/grep
+- ✅ Analyze code
+
+You must **NOT**:
+- ❌ Edit files
+- ❌ Write new files
+- ❌ Delete files
+- ❌ Modify anything
+
+## For Developers
+
+If you need to make changes to the torrent engine, work in the modern packages instead. This legacy code is preserved for reference only.


### PR DESCRIPTION
…ctory markers

- Implement TODO in TorrentFileInfo class to add proper priority handling
  - Add private _priority field with default value of 2 (normal priority)
  - Implement getter to return stored priority value
  - Add setter with validation to clamp priority to 0-3 range
  - Priority levels: 0=skip, 1=low, 2=normal, 3=high

- Add .claude/config.json to mark legacy-jstorrent-engine as read-only
  - Provides clear rules for Claude Code about which directories are read-only
  - Documents that legacy code should never be modified

- Add DO_NOT_EDIT.md marker in legacy-jstorrent-engine directory
  - Provides visible warning that the directory is read-only
  - Helps prevent accidental modifications to legacy code