### PR TITLE
Configure user email in CLAUDE.md file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Claude Instructions
+
+## Git Configuration and Commit Attribution
+
+### User Identity Management
+
+**CRITICAL**: When using Claude Code research preview (claude.ai/code), proper git commit attribution is required.
+
+#### Before ANY git push operations:
+
+1. **Check current git configuration**:
+   ```bash
+   git config user.name
+   git config user.email
+   ```
+
+2. **If the email is `noreply@anthropic.com` or name is just `Claude`**:
+   - **STOP** - Do not proceed with the push
+   - Ask the user which identity should be used for commits
+   - Configure git with the correct user details before pushing
+
+3. **Never push commits** with these default values:
+   - Name: `Claude`
+   - Email: `noreply@anthropic.com`
+
+#### Authorized Users
+
+| Name | Email |
+|------|-------|
+| Kyle Graehl | kgraehl@gmail.com |
+| Graehl Arts | graehlarts@gmail.com |
+
+#### Setting Git Config
+
+When the user confirms their identity, set git config:
+
+```bash
+git config user.name "User Name"
+git config user.email "user@email.com"
+```
+
+#### Workflow
+
+1. At the start of any session involving commits/pushes, verify git config
+2. If using placeholder values, ask: "Which user are you? (Kyle Graehl or Graehl Arts?)"
+3. Configure git with the appropriate credentials
+4. Proceed with commits and pushes
+
+This ensures proper commit history attribution across all work.


### PR DESCRIPTION
Add instructions for Claude to properly configure git user identity before making commits. Prevents pushing commits with placeholder Claude credentials and ensures proper commit attribution.

Includes authorized user list:
- Kyle Graehl (kgraehl@gmail.com)
- Graehl Arts (graehlarts@gmail.com)