### PR TITLE
Remove unused sessionStore public property from BtEngine

### DIFF
--- a/packages/engine/src/core/bt-engine.ts
+++ b/packages/engine/src/core/bt-engine.ts
@@ -61,7 +61,6 @@ export interface BtEngineOptions {
 export class BtEngine extends EventEmitter implements ILoggingEngine, ILoggableComponent {
   public readonly storageRootManager: StorageRootManager
   public readonly socketFactory: ISocketFactory
-  public readonly sessionStore: ISessionStore
   public readonly sessionPersistence: SessionPersistence
   public torrents: Torrent[] = []
   public port: number
@@ -110,8 +109,8 @@ export class BtEngine extends EventEmitter implements ILoggingEngine, ILoggableC
     } else {
       throw new Error('BtEngine requires storageRootManager or fileSystem + downloadPath')
     }
-    this.sessionStore = options.sessionStore ?? new MemorySessionStore()
-    this.sessionPersistence = new SessionPersistence(this.sessionStore, this)
+    const sessionStore = options.sessionStore ?? new MemorySessionStore()
+    this.sessionPersistence = new SessionPersistence(sessionStore, this)
     this.port = options.port ?? 6881 // Use nullish coalescing to allow port 0
 
     this.clientId = randomClientId()


### PR DESCRIPTION
The sessionStore was exposed as a public property but never used directly outside the constructor. It was only passed to SessionPersistence.

Now sessionStore is a local variable in the constructor, and all session operations go through sessionPersistence - the intended public API.