### PR TITLE
Implement Android MVP Phase 2: Main Screen (Torrent List)

### DIFF
--- a/android/app/src/androidTest/java/com/jstorrent/app/ui/dialogs/AddTorrentDialogTest.kt
+++ b/android/app/src/androidTest/java/com/jstorrent/app/ui/dialogs/AddTorrentDialogTest.kt
@@ -1,0 +1,212 @@
+package com.jstorrent.app.ui.dialogs
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.jstorrent.app.ui.theme.JSTorrentTheme
+import org.junit.Rule
+import org.junit.Test
+
+class AddTorrentDialogTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun emptyInput_addButtonDisabled() {
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = "",
+                    onMagnetLinkChange = {},
+                    onPasteFromClipboard = {},
+                    onAddTorrent = {},
+                    onCancel = {},
+                    isAddEnabled = false
+                )
+            }
+        }
+
+        // Verify Add button is disabled
+        composeTestRule.onNodeWithText("Add").assertIsNotEnabled()
+    }
+
+    @Test
+    fun validMagnet_addButtonEnabled() {
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = "magnet:?xt=urn:btih:abc123",
+                    onMagnetLinkChange = {},
+                    onPasteFromClipboard = {},
+                    onAddTorrent = {},
+                    onCancel = {},
+                    isAddEnabled = true
+                )
+            }
+        }
+
+        // Verify Add button is enabled
+        composeTestRule.onNodeWithText("Add").assertIsEnabled()
+    }
+
+    @Test
+    fun addButton_callsCallback() {
+        var addCalled = false
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = "magnet:?xt=urn:btih:abc123",
+                    onMagnetLinkChange = {},
+                    onPasteFromClipboard = {},
+                    onAddTorrent = { addCalled = true },
+                    onCancel = {},
+                    isAddEnabled = true
+                )
+            }
+        }
+
+        // Click Add button
+        composeTestRule.onNodeWithText("Add").performClick()
+
+        // Verify callback was called
+        assert(addCalled) { "Expected onAddTorrent to be called" }
+    }
+
+    @Test
+    fun cancelButton_callsCallback() {
+        var cancelCalled = false
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = "",
+                    onMagnetLinkChange = {},
+                    onPasteFromClipboard = {},
+                    onAddTorrent = {},
+                    onCancel = { cancelCalled = true },
+                    isAddEnabled = false
+                )
+            }
+        }
+
+        // Click Cancel button
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        // Verify callback was called
+        assert(cancelCalled) { "Expected onCancel to be called" }
+    }
+
+    @Test
+    fun pasteButton_callsCallback() {
+        var pasteCalled = false
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = "",
+                    onMagnetLinkChange = {},
+                    onPasteFromClipboard = { pasteCalled = true },
+                    onAddTorrent = {},
+                    onCancel = {},
+                    isAddEnabled = false
+                )
+            }
+        }
+
+        // Click paste button
+        composeTestRule.onNodeWithContentDescription("Paste from clipboard").performClick()
+
+        // Verify callback was called
+        assert(pasteCalled) { "Expected onPasteFromClipboard to be called" }
+    }
+
+    @Test
+    fun textInput_triggersOnChange() {
+        var inputValue = ""
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = inputValue,
+                    onMagnetLinkChange = { inputValue = it },
+                    onPasteFromClipboard = {},
+                    onAddTorrent = {},
+                    onCancel = {},
+                    isAddEnabled = inputValue.isNotBlank()
+                )
+            }
+        }
+
+        // Type in the text field
+        composeTestRule.onNodeWithText("Magnet link").performTextInput("magnet:?xt=urn:btih:test")
+
+        // Verify the callback was triggered
+        assert(inputValue == "magnet:?xt=urn:btih:test") {
+            "Expected input to be 'magnet:?xt=urn:btih:test', got '$inputValue'"
+        }
+    }
+
+    @Test
+    fun dialogTitle_isDisplayed() {
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = "",
+                    onMagnetLinkChange = {},
+                    onPasteFromClipboard = {},
+                    onAddTorrent = {},
+                    onCancel = {},
+                    isAddEnabled = false
+                )
+            }
+        }
+
+        // Verify title is displayed
+        composeTestRule.onNodeWithText("Add Torrent").assertIsDisplayed()
+    }
+
+    @Test
+    fun placeholder_isDisplayed() {
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                AddTorrentContent(
+                    magnetLink = "",
+                    onMagnetLinkChange = {},
+                    onPasteFromClipboard = {},
+                    onAddTorrent = {},
+                    onCancel = {},
+                    isAddEnabled = false
+                )
+            }
+        }
+
+        // Verify placeholder is displayed
+        composeTestRule.onNodeWithText("magnet:?xt=urn:btih:...").assertIsDisplayed()
+    }
+}
+
+// Unit tests for validation function
+class MagnetLinkValidationTest {
+
+    @Test
+    fun validMagnetLink_returnsTrue() {
+        assert(isValidMagnetLink("magnet:?xt=urn:btih:abc123"))
+        assert(isValidMagnetLink("MAGNET:?XT=URN:BTIH:ABC123")) // case insensitive
+        assert(isValidMagnetLink("  magnet:?xt=urn:btih:abc123  ")) // with whitespace
+    }
+
+    @Test
+    fun invalidMagnetLink_returnsFalse() {
+        assert(!isValidMagnetLink(""))
+        assert(!isValidMagnetLink("http://example.com"))
+        assert(!isValidMagnetLink("magnet:"))
+        assert(!isValidMagnetLink("urn:btih:abc123"))
+    }
+}

--- a/android/app/src/androidTest/java/com/jstorrent/app/ui/screens/TorrentListScreenTest.kt
+++ b/android/app/src/androidTest/java/com/jstorrent/app/ui/screens/TorrentListScreenTest.kt
@@ -1,0 +1,213 @@
+package com.jstorrent.app.ui.screens
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.jstorrent.app.model.TorrentFilter
+import com.jstorrent.app.model.TorrentListUiState
+import com.jstorrent.app.model.TorrentSortOrder
+import com.jstorrent.app.ui.theme.JSTorrentTheme
+import com.jstorrent.app.viewmodel.FakeTorrentRepository
+import com.jstorrent.app.viewmodel.TorrentListViewModel
+import com.jstorrent.quickjs.model.TorrentSummary
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TorrentListScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var fakeRepository: FakeTorrentRepository
+    private lateinit var viewModel: TorrentListViewModel
+
+    @Before
+    fun setup() {
+        fakeRepository = FakeTorrentRepository()
+        viewModel = TorrentListViewModel(fakeRepository)
+    }
+
+    @Test
+    fun emptyState_showsMessage() {
+        // Set up empty list
+        fakeRepository.setLoaded(true)
+        fakeRepository.setTorrents(emptyList())
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(viewModel = viewModel)
+            }
+        }
+
+        // Verify empty state message is shown
+        composeTestRule.onNodeWithText("No torrents yet").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Tap + to add a magnet link").assertIsDisplayed()
+    }
+
+    @Test
+    fun torrentList_showsAllTorrents() {
+        // Set up with torrents
+        val torrents = listOf(
+            createTestTorrent("hash1", "Ubuntu ISO", 0.45, "downloading"),
+            createTestTorrent("hash2", "Debian ISO", 0.75, "stopped"),
+            createTestTorrent("hash3", "Fedora ISO", 1.0, "seeding")
+        )
+        fakeRepository.setLoaded(true)
+        fakeRepository.setTorrents(torrents)
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(viewModel = viewModel)
+            }
+        }
+
+        // Verify all torrents are shown
+        composeTestRule.onNodeWithText("Ubuntu ISO").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Debian ISO").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Fedora ISO").assertIsDisplayed()
+    }
+
+    @Test
+    fun torrentCard_tapNavigatesToDetail() {
+        var clickedHash: String? = null
+        val torrents = listOf(
+            createTestTorrent("hash1", "Test Torrent", 0.5, "downloading")
+        )
+        fakeRepository.setLoaded(true)
+        fakeRepository.setTorrents(torrents)
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(
+                    viewModel = viewModel,
+                    onTorrentClick = { clickedHash = it }
+                )
+            }
+        }
+
+        // Click on torrent
+        composeTestRule.onNodeWithText("Test Torrent").performClick()
+
+        // Verify click callback was called
+        assert(clickedHash == "hash1") { "Expected hash1, got $clickedHash" }
+    }
+
+    @Test
+    fun fab_showsAddDialog() {
+        fakeRepository.setLoaded(true)
+        fakeRepository.setTorrents(emptyList())
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(viewModel = viewModel)
+            }
+        }
+
+        // Click FAB
+        composeTestRule.onNodeWithContentDescription("Add torrent").performClick()
+
+        // Verify dialog is shown
+        composeTestRule.onNodeWithText("Add Torrent").assertIsDisplayed()
+    }
+
+    @Test
+    fun filterTabs_switchBetweenFilters() {
+        val torrents = listOf(
+            createTestTorrent("hash1", "Downloading Torrent", 0.45, "downloading"),
+            createTestTorrent("hash2", "Finished Torrent", 1.0, "seeding")
+        )
+        fakeRepository.setLoaded(true)
+        fakeRepository.setTorrents(torrents)
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(viewModel = viewModel)
+            }
+        }
+
+        // Initially on ALL tab - both torrents shown
+        composeTestRule.onNodeWithText("Downloading Torrent").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Finished Torrent").assertIsDisplayed()
+
+        // Click Queued tab
+        composeTestRule.onNodeWithText("Queued (1)").performClick()
+
+        // Only downloading torrent should be visible
+        composeTestRule.onNodeWithText("Downloading Torrent").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Finished Torrent").assertDoesNotExist()
+
+        // Click Finished tab
+        composeTestRule.onNodeWithText("Finished (1)").performClick()
+
+        // Only finished torrent should be visible
+        composeTestRule.onNodeWithText("Finished Torrent").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Downloading Torrent").assertDoesNotExist()
+    }
+
+    @Test
+    fun overflowMenu_showsPauseResumeOptions() {
+        fakeRepository.setLoaded(true)
+        fakeRepository.setTorrents(emptyList())
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(viewModel = viewModel)
+            }
+        }
+
+        // Open overflow menu
+        composeTestRule.onNodeWithContentDescription("Menu").performClick()
+
+        // Verify menu items
+        composeTestRule.onNodeWithText("Pause All").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Resume All").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add Download Folder").assertIsDisplayed()
+    }
+
+    @Test
+    fun loadingState_showsLoadingIndicator() {
+        fakeRepository.setLoaded(false)
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(viewModel = viewModel)
+            }
+        }
+
+        // Verify loading state is shown
+        composeTestRule.onNodeWithText("Starting engine...").assertIsDisplayed()
+    }
+
+    @Test
+    fun errorState_showsErrorMessage() {
+        fakeRepository.setError("Failed to connect")
+
+        composeTestRule.setContent {
+            JSTorrentTheme {
+                TorrentListScreen(viewModel = viewModel)
+            }
+        }
+
+        // Verify error state is shown
+        composeTestRule.onNodeWithText("Error").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Failed to connect").assertIsDisplayed()
+    }
+
+    // Helper function
+    private fun createTestTorrent(
+        hash: String,
+        name: String,
+        progress: Double,
+        status: String
+    ) = TorrentSummary(
+        infoHash = hash,
+        name = name,
+        progress = progress,
+        downloadSpeed = if (status == "downloading") 1_000_000L else 0L,
+        uploadSpeed = if (status == "seeding") 500_000L else 0L,
+        status = status
+    )
+}

--- a/android/app/src/androidTest/java/com/jstorrent/app/viewmodel/FakeTorrentRepository.kt
+++ b/android/app/src/androidTest/java/com/jstorrent/app/viewmodel/FakeTorrentRepository.kt
@@ -1,0 +1,166 @@
+package com.jstorrent.app.viewmodel
+
+import com.jstorrent.quickjs.model.EngineState
+import com.jstorrent.quickjs.model.FileInfo
+import com.jstorrent.quickjs.model.TorrentInfo
+import com.jstorrent.quickjs.model.TorrentSummary
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Fake TorrentRepository for testing.
+ * Allows tests to control the state and verify interactions.
+ */
+class FakeTorrentRepository : TorrentRepository {
+
+    private val _state = MutableStateFlow<EngineState?>(null)
+    override val state: StateFlow<EngineState?> = _state.asStateFlow()
+
+    private val _isLoaded = MutableStateFlow(false)
+    override val isLoaded: StateFlow<Boolean> = _isLoaded.asStateFlow()
+
+    private val _lastError = MutableStateFlow<String?>(null)
+    override val lastError: StateFlow<String?> = _lastError.asStateFlow()
+
+    // Track method calls for verification
+    val addedTorrents = mutableListOf<String>()
+    val pausedTorrents = mutableListOf<String>()
+    val resumedTorrents = mutableListOf<String>()
+    val removedTorrents = mutableListOf<Pair<String, Boolean>>()
+    var pauseAllCalled = false
+    var resumeAllCalled = false
+
+    // Data for queries
+    var torrentListData: List<TorrentInfo> = emptyList()
+    var filesData: Map<String, List<FileInfo>> = emptyMap()
+
+    // ==========================================================================
+    // Test control methods
+    // ==========================================================================
+
+    fun setLoaded(loaded: Boolean) {
+        _isLoaded.value = loaded
+    }
+
+    fun setError(error: String?) {
+        _lastError.value = error
+    }
+
+    fun setTorrents(torrents: List<TorrentSummary>) {
+        _state.value = EngineState(torrents)
+    }
+
+    fun reset() {
+        _state.value = null
+        _isLoaded.value = false
+        _lastError.value = null
+        addedTorrents.clear()
+        pausedTorrents.clear()
+        resumedTorrents.clear()
+        removedTorrents.clear()
+        pauseAllCalled = false
+        resumeAllCalled = false
+        torrentListData = emptyList()
+        filesData = emptyMap()
+    }
+
+    // ==========================================================================
+    // TorrentRepository implementation
+    // ==========================================================================
+
+    override fun addTorrent(magnetOrBase64: String) {
+        addedTorrents.add(magnetOrBase64)
+    }
+
+    override fun pauseTorrent(infoHash: String) {
+        pausedTorrents.add(infoHash)
+        // Update state to reflect pause
+        _state.value?.let { currentState ->
+            val updatedTorrents = currentState.torrents.map { torrent ->
+                if (torrent.infoHash == infoHash) {
+                    torrent.copy(status = "stopped", downloadSpeed = 0, uploadSpeed = 0)
+                } else {
+                    torrent
+                }
+            }
+            _state.value = EngineState(updatedTorrents)
+        }
+    }
+
+    override fun resumeTorrent(infoHash: String) {
+        resumedTorrents.add(infoHash)
+        // Update state to reflect resume
+        _state.value?.let { currentState ->
+            val updatedTorrents = currentState.torrents.map { torrent ->
+                if (torrent.infoHash == infoHash) {
+                    torrent.copy(status = "downloading")
+                } else {
+                    torrent
+                }
+            }
+            _state.value = EngineState(updatedTorrents)
+        }
+    }
+
+    override fun removeTorrent(infoHash: String, deleteFiles: Boolean) {
+        removedTorrents.add(Pair(infoHash, deleteFiles))
+        // Update state to reflect removal
+        _state.value?.let { currentState ->
+            val updatedTorrents = currentState.torrents.filter { it.infoHash != infoHash }
+            _state.value = EngineState(updatedTorrents)
+        }
+    }
+
+    override fun pauseAll() {
+        pauseAllCalled = true
+        _state.value?.let { currentState ->
+            val updatedTorrents = currentState.torrents.map { torrent ->
+                torrent.copy(status = "stopped", downloadSpeed = 0, uploadSpeed = 0)
+            }
+            _state.value = EngineState(updatedTorrents)
+        }
+    }
+
+    override fun resumeAll() {
+        resumeAllCalled = true
+        _state.value?.let { currentState ->
+            val updatedTorrents = currentState.torrents.map { torrent ->
+                if (torrent.status == "stopped") {
+                    torrent.copy(status = "downloading")
+                } else {
+                    torrent
+                }
+            }
+            _state.value = EngineState(updatedTorrents)
+        }
+    }
+
+    override fun getTorrentList(): List<TorrentInfo> {
+        return torrentListData
+    }
+
+    override fun getFiles(infoHash: String): List<FileInfo> {
+        return filesData[infoHash] ?: emptyList()
+    }
+}
+
+// ==========================================================================
+// Test data helpers
+// ==========================================================================
+
+fun createTestTorrent(
+    infoHash: String = "abc123",
+    name: String = "Test Torrent",
+    progress: Double = 0.5,
+    downloadSpeed: Long = 1000000,
+    uploadSpeed: Long = 50000,
+    status: String = "downloading"
+) = TorrentSummary(
+    infoHash = infoHash,
+    name = name,
+    progress = progress,
+    downloadSpeed = downloadSpeed,
+    uploadSpeed = uploadSpeed,
+    status = status
+)

--- a/android/app/src/main/java/com/jstorrent/app/NativeStandaloneActivity.kt
+++ b/android/app/src/main/java/com/jstorrent/app/NativeStandaloneActivity.kt
@@ -8,21 +8,30 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.jstorrent.app.service.EngineService
 import com.jstorrent.app.storage.RootStore
+import com.jstorrent.app.ui.screens.TorrentListScreen
 import com.jstorrent.app.ui.theme.JSTorrentTheme
-import com.jstorrent.quickjs.model.TorrentSummary
+import com.jstorrent.app.viewmodel.TorrentListViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -36,12 +45,13 @@ class NativeStandaloneActivity : ComponentActivity() {
 
     private lateinit var rootStore: RootStore
 
+    // ViewModel for torrent list
+    private val viewModel: TorrentListViewModel by viewModels {
+        TorrentListViewModel.Factory()
+    }
+
     // UI State
     private var hasRoots = mutableStateOf(false)
-    private var magnetInput = mutableStateOf("")
-    private var torrents = mutableStateOf<List<TorrentSummary>>(emptyList())
-    private var isEngineLoaded = mutableStateOf(false)
-    private var lastError = mutableStateOf<String?>(null)
     private var testStorageMode = mutableStateOf<String?>(null)
 
     // For handling magnet intents while engine is loading
@@ -65,44 +75,31 @@ class NativeStandaloneActivity : ComponentActivity() {
 
         setContent {
             JSTorrentTheme {
-                NativeStandaloneScreen(
-                    hasRoots = hasRoots.value || testStorageMode.value != null,
-                    magnetInput = magnetInput.value,
-                    onMagnetInputChange = { magnetInput.value = it },
-                    onAddTorrent = { addTorrent(it) },
-                    torrents = torrents.value,
-                    isEngineLoaded = isEngineLoaded.value,
-                    lastError = lastError.value,
-                    onAddRoot = { launchAddRoot() },
-                    onPauseTorrent = { hash -> EngineService.instance?.pauseTorrent(hash) },
-                    onResumeTorrent = { hash -> EngineService.instance?.resumeTorrent(hash) },
-                    onRemoveTorrent = { hash -> EngineService.instance?.removeTorrent(hash, false) },
-                    onSwitchToWebView = { switchToWebViewMode() },
-                    onAddTestTorrent = { EngineService.instance?.addTestTorrent() }
-                )
+                if (!hasRoots.value && testStorageMode.value == null) {
+                    // Setup required
+                    SetupRequiredScreen(onAddRoot = { launchAddRoot() })
+                } else {
+                    // Main torrent list screen
+                    TorrentListScreen(
+                        viewModel = viewModel,
+                        onTorrentClick = { infoHash ->
+                            // TODO: Navigate to detail screen in Phase 3
+                            Log.d(TAG, "Torrent clicked: $infoHash")
+                        },
+                        onAddRootClick = { launchAddRoot() },
+                        onSearchClick = {
+                            // TODO: Implement search in future phase
+                            Log.d(TAG, "Search clicked")
+                        }
+                    )
+                }
             }
         }
     }
 
-    private fun switchToWebViewMode() {
-        // Stop the engine service
-        EngineService.stop(this)
-        
-        // Save preference for WebView mode
-        getSharedPreferences("jstorrent", MODE_PRIVATE).edit()
-            .putString("standalone_mode", "webview")
-            .apply()
-        
-        // Launch WebView standalone activity
-        startActivity(Intent(this, StandaloneActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        })
-        finish()
-    }
-
     override fun onStart() {
         super.onStart()
-        observeEngineState()
+        observeEngineForPendingMagnet()
     }
 
     override fun onResume() {
@@ -156,11 +153,7 @@ class NativeStandaloneActivity : ComponentActivity() {
         when (uri.scheme) {
             "magnet" -> {
                 val magnet = uri.toString()
-                if (isEngineLoaded.value) {
-                    addTorrent(magnet)
-                } else {
-                    pendingMagnet = magnet
-                }
+                addOrQueueMagnet(magnet)
             }
             "content", "file" -> {
                 handleTorrentFile(uri)
@@ -181,28 +174,35 @@ class NativeStandaloneActivity : ComponentActivity() {
                 if (!magnetB64.isNullOrEmpty()) {
                     val magnet = String(Base64.decode(magnetB64, Base64.DEFAULT), Charsets.UTF_8)
                     Log.i(TAG, "Magnet from base64 param: $magnet")
-                    if (isEngineLoaded.value) {
-                        addTorrent(magnet)
-                    } else {
-                        pendingMagnet = magnet
-                    }
+                    addOrQueueMagnet(magnet)
                 } else {
                     // Fallback: Check for plain magnet query parameter
                     val magnetParam = uri.getQueryParameter("magnet")
                     if (!magnetParam.isNullOrEmpty()) {
                         Log.i(TAG, "Magnet from query param: $magnetParam")
-                        if (isEngineLoaded.value) {
-                            addTorrent(magnetParam)
-                        } else {
-                            pendingMagnet = magnetParam
-                        }
+                        addOrQueueMagnet(magnetParam)
                     }
                 }
             }
         }
     }
 
-    private fun observeEngineState() {
+    /**
+     * Add magnet immediately if engine is loaded, otherwise queue it.
+     */
+    private fun addOrQueueMagnet(magnet: String) {
+        val service = EngineService.instance
+        if (service != null && service.isLoaded?.value == true) {
+            viewModel.addTorrent(magnet)
+        } else {
+            pendingMagnet = magnet
+        }
+    }
+
+    /**
+     * Observe engine load state to add pending magnets.
+     */
+    private fun observeEngineForPendingMagnet() {
         lifecycleScope.launch {
             // Wait for service instance
             while (EngineService.instance == null) {
@@ -211,38 +211,14 @@ class NativeStandaloneActivity : ComponentActivity() {
 
             val service = EngineService.instance!!
 
-            // Collect isLoaded
-            launch {
-                service.isLoaded?.collect { loaded ->
-                    isEngineLoaded.value = loaded
-                    // Handle pending magnet when engine becomes ready
-                    if (loaded && pendingMagnet != null) {
-                        addTorrent(pendingMagnet!!)
-                        pendingMagnet = null
-                    }
-                }
-            }
-
-            // Collect state updates
-            launch {
-                service.state?.collect { state ->
-                    torrents.value = state?.torrents ?: emptyList()
-                }
-            }
-
-            // Collect errors
-            launch {
-                service.lastError?.collect { error ->
-                    lastError.value = error
+            // Collect isLoaded to handle pending magnet
+            service.isLoaded?.collect { loaded ->
+                if (loaded && pendingMagnet != null) {
+                    viewModel.addTorrent(pendingMagnet!!)
+                    pendingMagnet = null
                 }
             }
         }
-    }
-
-    private fun addTorrent(magnetOrBase64: String) {
-        if (magnetOrBase64.isBlank()) return
-        EngineService.instance?.addTorrent(magnetOrBase64)
-        magnetInput.value = ""  // Clear input
     }
 
     private fun handleTorrentFile(uri: Uri) {
@@ -250,15 +226,10 @@ class NativeStandaloneActivity : ComponentActivity() {
             val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
             if (bytes != null) {
                 val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
-                if (isEngineLoaded.value) {
-                    addTorrent(base64)
-                } else {
-                    pendingMagnet = base64
-                }
+                addOrQueueMagnet(base64)
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read torrent file", e)
-            lastError.value = "Failed to read torrent file: ${e.message}"
         }
     }
 
@@ -268,327 +239,47 @@ class NativeStandaloneActivity : ComponentActivity() {
 }
 
 // =============================================================================
-// Composables
+// Setup Required Screen
 // =============================================================================
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Screen shown when no download folder is configured.
+ */
 @Composable
-fun NativeStandaloneScreen(
-    hasRoots: Boolean,
-    magnetInput: String,
-    onMagnetInputChange: (String) -> Unit,
-    onAddTorrent: (String) -> Unit,
-    torrents: List<TorrentSummary>,
-    isEngineLoaded: Boolean,
-    lastError: String?,
+fun SetupRequiredScreen(
     onAddRoot: () -> Unit,
-    onPauseTorrent: (String) -> Unit,
-    onResumeTorrent: (String) -> Unit,
-    onRemoveTorrent: (String) -> Unit,
-    onSwitchToWebView: () -> Unit,
-    onAddTestTorrent: () -> Unit = {}
+    modifier: Modifier = Modifier
 ) {
-    var showMenu by remember { mutableStateOf(false) }
-    
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        topBar = {
-            TopAppBar(
-                title = { Text("JSTorrent (Native)") },
-                actions = {
-                    IconButton(onClick = { showMenu = true }) {
-                        Icon(
-                            imageVector = Icons.Default.MoreVert,
-                            contentDescription = "Menu"
-                        )
-                    }
-                    DropdownMenu(
-                        expanded = showMenu,
-                        onDismissRequest = { showMenu = false }
-                    ) {
-                        DropdownMenuItem(
-                            text = { Text("Add Test Torrent") },
-                            onClick = {
-                                showMenu = false
-                                onAddTestTorrent()
-                            }
-                        )
-                        DropdownMenuItem(
-                            text = { Text("Add Download Folder") },
-                            onClick = {
-                                showMenu = false
-                                onAddRoot()
-                            }
-                        )
-                        HorizontalDivider()
-                        DropdownMenuItem(
-                            text = { Text("Switch to WebView Mode") },
-                            onClick = {
-                                showMenu = false
-                                onSwitchToWebView()
-                            }
-                        )
-                    }
-                }
-            )
-        }
-    ) { innerPadding ->
-        Column(
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Card(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(16.dp)
-        ) {
-            // Error banner
-            lastError?.let { error ->
-                Card(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer
-                    ),
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(
-                        text = error,
-                        modifier = Modifier.padding(12.dp),
-                        color = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
-            if (!hasRoots) {
-                // Setup required
-                SetupRequiredCard(onAddRoot = onAddRoot)
-            } else if (!isEngineLoaded) {
-                // Loading state
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        CircularProgressIndicator()
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "Starting engine...",
-                            style = MaterialTheme.typography.bodyLarge
-                        )
-                    }
-                }
-            } else {
-                // Main UI
-                AddTorrentRow(
-                    magnetInput = magnetInput,
-                    onMagnetInputChange = onMagnetInputChange,
-                    onAddTorrent = onAddTorrent
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Torrent list
-                if (torrents.isEmpty()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = "No torrents yet",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = "Paste a magnet link above to get started",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                } else {
-                    LazyColumn(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        items(torrents, key = { it.infoHash }) { torrent ->
-                            TorrentCard(
-                                torrent = torrent,
-                                onPause = { onPauseTorrent(torrent.infoHash) },
-                                onResume = { onResumeTorrent(torrent.infoHash) },
-                                onRemove = { onRemoveTorrent(torrent.infoHash) }
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun SetupRequiredCard(onAddRoot: () -> Unit) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
-        )
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = "Setup Required",
-                style = MaterialTheme.typography.titleMedium
+                .fillMaxWidth()
+                .padding(32.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "Please select a download folder to store your torrents.",
-                style = MaterialTheme.typography.bodyMedium
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = onAddRoot) {
-                Text("Select Download Folder")
-            }
-        }
-    }
-}
-
-@Composable
-fun AddTorrentRow(
-    magnetInput: String,
-    onMagnetInputChange: (String) -> Unit,
-    onAddTorrent: (String) -> Unit
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        OutlinedTextField(
-            value = magnetInput,
-            onValueChange = onMagnetInputChange,
-            modifier = Modifier.weight(1f),
-            placeholder = { Text("Paste magnet link...") },
-            singleLine = true
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Button(
-            onClick = { onAddTorrent(magnetInput) },
-            enabled = magnetInput.isNotBlank()
         ) {
-            Text("Add")
-        }
-    }
-}
-
-@Composable
-fun TorrentCard(
-    torrent: TorrentSummary,
-    onPause: () -> Unit,
-    onResume: () -> Unit,
-    onRemove: () -> Unit
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            modifier = Modifier.padding(12.dp)
-        ) {
-            // Name
-            Text(
-                text = torrent.name.ifEmpty { "Unknown" },
-                style = MaterialTheme.typography.titleSmall,
-                maxLines = 2
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Status + Speed
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = formatStatus(torrent.status),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = statusColor(torrent.status)
+                    text = "Setup Required",
+                    style = MaterialTheme.typography.titleLarge
                 )
+                Spacer(modifier = Modifier.height(12.dp))
                 Text(
-                    text = formatSpeed(torrent.downloadSpeed),
-                    style = MaterialTheme.typography.bodySmall
+                    text = "Please select a download folder to store your torrents.",
+                    style = MaterialTheme.typography.bodyMedium
                 )
-            }
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            // Progress bar
-            LinearProgressIndicator(
-                progress = { torrent.progress.toFloat().coerceIn(0f, 1f) },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            // Progress percentage
-            Text(
-                text = "${(torrent.progress * 100).toInt()}%",
-                style = MaterialTheme.typography.bodySmall
-            )
-
-            // Action buttons
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
-            ) {
-                if (torrent.status == "stopped") {
-                    TextButton(onClick = onResume) {
-                        Text("Resume")
-                    }
-                } else {
-                    TextButton(onClick = onPause) {
-                        Text("Pause")
-                    }
-                }
-                TextButton(onClick = onRemove) {
-                    Text("Remove")
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(onClick = onAddRoot) {
+                    Text("Select Download Folder")
                 }
             }
         }
-    }
-}
-
-// =============================================================================
-// Helper Functions
-// =============================================================================
-
-@Composable
-private fun statusColor(status: String) = when (status) {
-    "downloading" -> MaterialTheme.colorScheme.primary
-    "seeding" -> MaterialTheme.colorScheme.tertiary
-    "stopped" -> MaterialTheme.colorScheme.outline
-    "checking" -> MaterialTheme.colorScheme.secondary
-    "error" -> MaterialTheme.colorScheme.error
-    else -> MaterialTheme.colorScheme.onSurface
-}
-
-private fun formatStatus(status: String): String = when (status) {
-    "downloading" -> "Downloading"
-    "downloading_metadata" -> "Getting metadata..."
-    "seeding" -> "Seeding"
-    "stopped" -> "Paused"
-    "checking" -> "Checking..."
-    "error" -> "Error"
-    else -> status.replaceFirstChar { it.uppercase() }
-}
-
-private fun formatSpeed(bytesPerSecond: Long): String {
-    return when {
-        bytesPerSecond >= 1_000_000 -> "${bytesPerSecond / 1_000_000} MB/s"
-        bytesPerSecond >= 1_000 -> "${bytesPerSecond / 1_000} KB/s"
-        bytesPerSecond > 0 -> "$bytesPerSecond B/s"
-        else -> ""
     }
 }

--- a/android/app/src/main/java/com/jstorrent/app/model/UiState.kt
+++ b/android/app/src/main/java/com/jstorrent/app/model/UiState.kt
@@ -39,13 +39,13 @@ sealed class TorrentListUiState {
 /**
  * Filter options for torrent list.
  */
-enum class TorrentFilter {
+enum class TorrentFilter(val displayName: String) {
     /** Show all torrents */
-    ALL,
+    ALL("All"),
     /** Show active/queued torrents (downloading, downloading_metadata, checking) */
-    QUEUED,
+    QUEUED("Queued"),
     /** Show completed torrents (seeding, stopped with progress = 1.0) */
-    FINISHED
+    FINISHED("Finished")
 }
 
 /**

--- a/android/app/src/main/java/com/jstorrent/app/ui/dialogs/AddTorrentDialog.kt
+++ b/android/app/src/main/java/com/jstorrent/app/ui/dialogs/AddTorrentDialog.kt
@@ -1,0 +1,198 @@
+package com.jstorrent.app.ui.dialogs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentPaste
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.jstorrent.app.ui.theme.JSTorrentTheme
+import kotlinx.coroutines.launch
+
+/**
+ * Bottom sheet dialog for adding a torrent via magnet link.
+ *
+ * @param onDismiss Called when the dialog is dismissed
+ * @param onAddTorrent Called with the magnet link when user taps Add
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddTorrentDialog(
+    onDismiss: () -> Unit,
+    onAddTorrent: (String) -> Unit,
+    sheetState: SheetState = rememberModalBottomSheetState()
+) {
+    var magnetLink by remember { mutableStateOf("") }
+    val clipboardManager = LocalClipboardManager.current
+    val scope = rememberCoroutineScope()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        AddTorrentContent(
+            magnetLink = magnetLink,
+            onMagnetLinkChange = { magnetLink = it },
+            onPasteFromClipboard = {
+                clipboardManager.getText()?.text?.let { text ->
+                    magnetLink = text
+                }
+            },
+            onAddTorrent = {
+                if (magnetLink.isNotBlank()) {
+                    onAddTorrent(magnetLink)
+                    scope.launch {
+                        sheetState.hide()
+                        onDismiss()
+                    }
+                }
+            },
+            onCancel = {
+                scope.launch {
+                    sheetState.hide()
+                    onDismiss()
+                }
+            },
+            isAddEnabled = magnetLink.isNotBlank()
+        )
+    }
+}
+
+/**
+ * Content for the add torrent dialog.
+ * Extracted for easier testing and previews.
+ */
+@Composable
+fun AddTorrentContent(
+    magnetLink: String,
+    onMagnetLinkChange: (String) -> Unit,
+    onPasteFromClipboard: () -> Unit,
+    onAddTorrent: () -> Unit,
+    onCancel: () -> Unit,
+    isAddEnabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 32.dp)
+    ) {
+        // Title
+        Text(
+            text = "Add Torrent",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        // Magnet link input with paste button
+        OutlinedTextField(
+            value = magnetLink,
+            onValueChange = onMagnetLinkChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Magnet link") },
+            placeholder = { Text("magnet:?xt=urn:btih:...") },
+            singleLine = false,
+            maxLines = 3,
+            trailingIcon = {
+                IconButton(onClick = onPasteFromClipboard) {
+                    Icon(
+                        imageVector = Icons.Default.ContentPaste,
+                        contentDescription = "Paste from clipboard"
+                    )
+                }
+            }
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Action buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Cancel")
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Button(
+                onClick = onAddTorrent,
+                modifier = Modifier.weight(1f),
+                enabled = isAddEnabled
+            ) {
+                Text("Add")
+            }
+        }
+    }
+}
+
+/**
+ * Validates if a string looks like a magnet link.
+ */
+fun isValidMagnetLink(input: String): Boolean {
+    return input.trim().startsWith("magnet:?xt=urn:btih:", ignoreCase = true)
+}
+
+// =============================================================================
+// Previews
+// =============================================================================
+
+@Preview(showBackground = true)
+@Composable
+private fun AddTorrentContentEmptyPreview() {
+    JSTorrentTheme {
+        AddTorrentContent(
+            magnetLink = "",
+            onMagnetLinkChange = {},
+            onPasteFromClipboard = {},
+            onAddTorrent = {},
+            onCancel = {},
+            isAddEnabled = false
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddTorrentContentWithLinkPreview() {
+    JSTorrentTheme {
+        AddTorrentContent(
+            magnetLink = "magnet:?xt=urn:btih:abc123",
+            onMagnetLinkChange = {},
+            onPasteFromClipboard = {},
+            onAddTorrent = {},
+            onCancel = {},
+            isAddEnabled = true
+        )
+    }
+}

--- a/android/app/src/main/java/com/jstorrent/app/ui/screens/TorrentListScreen.kt
+++ b/android/app/src/main/java/com/jstorrent/app/ui/screens/TorrentListScreen.kt
@@ -1,0 +1,367 @@
+package com.jstorrent.app.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.jstorrent.app.model.TorrentFilter
+import com.jstorrent.app.model.TorrentListUiState
+import com.jstorrent.app.ui.components.TorrentCard
+import com.jstorrent.app.ui.dialogs.AddTorrentDialog
+import com.jstorrent.app.ui.theme.JSTorrentTheme
+import com.jstorrent.app.viewmodel.TorrentListViewModel
+import com.jstorrent.quickjs.model.TorrentSummary
+
+/**
+ * Main torrent list screen.
+ * Displays a list of torrents with filter tabs, search, and add FAB.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TorrentListScreen(
+    viewModel: TorrentListViewModel,
+    onTorrentClick: (String) -> Unit = {},
+    onAddRootClick: () -> Unit = {},
+    onSearchClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val currentFilter by viewModel.filter.collectAsState()
+
+    var showAddDialog by remember { mutableStateOf(false) }
+    var showMenu by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("JSTorrent") },
+                actions = {
+                    IconButton(onClick = onSearchClick) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = "Search"
+                        )
+                    }
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = "Menu"
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Pause All") },
+                            onClick = {
+                                showMenu = false
+                                viewModel.pauseAll()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Resume All") },
+                            onClick = {
+                                showMenu = false
+                                viewModel.resumeAll()
+                            }
+                        )
+                        HorizontalDivider()
+                        DropdownMenuItem(
+                            text = { Text("Add Download Folder") },
+                            onClick = {
+                                showMenu = false
+                                onAddRootClick()
+                            }
+                        )
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            if (uiState is TorrentListUiState.Loaded) {
+                FloatingActionButton(
+                    onClick = { showAddDialog = true }
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = "Add torrent"
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        when (val state = uiState) {
+            is TorrentListUiState.Loading -> {
+                LoadingContent(modifier = Modifier.padding(innerPadding))
+            }
+            is TorrentListUiState.Error -> {
+                ErrorContent(
+                    message = state.message,
+                    modifier = Modifier.padding(innerPadding)
+                )
+            }
+            is TorrentListUiState.Loaded -> {
+                TorrentListContent(
+                    torrents = state.torrents,
+                    currentFilter = currentFilter,
+                    onFilterChange = { viewModel.setFilter(it) },
+                    getFilterCount = { viewModel.getFilterCount(it) },
+                    onTorrentClick = onTorrentClick,
+                    onPauseTorrent = { viewModel.pauseTorrent(it) },
+                    onResumeTorrent = { viewModel.resumeTorrent(it) },
+                    isPaused = { viewModel.isPaused(it) },
+                    modifier = Modifier.padding(innerPadding)
+                )
+            }
+        }
+    }
+
+    // Add torrent dialog
+    if (showAddDialog) {
+        AddTorrentDialog(
+            onDismiss = { showAddDialog = false },
+            onAddTorrent = { magnetLink ->
+                viewModel.addTorrent(magnetLink)
+                showAddDialog = false
+            }
+        )
+    }
+}
+
+/**
+ * Content shown while loading.
+ */
+@Composable
+private fun LoadingContent(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Starting engine...",
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
+
+/**
+ * Content shown on error.
+ */
+@Composable
+private fun ErrorContent(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Text(
+                text = "Error",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+/**
+ * Main content with filter tabs and torrent list.
+ */
+@Composable
+private fun TorrentListContent(
+    torrents: List<TorrentSummary>,
+    currentFilter: TorrentFilter,
+    onFilterChange: (TorrentFilter) -> Unit,
+    getFilterCount: (TorrentFilter) -> Int,
+    onTorrentClick: (String) -> Unit,
+    onPauseTorrent: (String) -> Unit,
+    onResumeTorrent: (String) -> Unit,
+    isPaused: (TorrentSummary) -> Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        // Filter tabs
+        FilterTabRow(
+            currentFilter = currentFilter,
+            onFilterChange = onFilterChange,
+            getFilterCount = getFilterCount
+        )
+
+        // Torrent list or empty state
+        if (torrents.isEmpty()) {
+            EmptyState(currentFilter = currentFilter)
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(torrents, key = { it.infoHash }) { torrent ->
+                    TorrentCard(
+                        torrent = torrent,
+                        onPause = { onPauseTorrent(torrent.infoHash) },
+                        onResume = { onResumeTorrent(torrent.infoHash) },
+                        onClick = { onTorrentClick(torrent.infoHash) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Filter tab row: ALL | QUEUED | FINISHED
+ */
+@Composable
+private fun FilterTabRow(
+    currentFilter: TorrentFilter,
+    onFilterChange: (TorrentFilter) -> Unit,
+    getFilterCount: (TorrentFilter) -> Int,
+    modifier: Modifier = Modifier
+) {
+    val tabs = listOf(TorrentFilter.ALL, TorrentFilter.QUEUED, TorrentFilter.FINISHED)
+    val selectedIndex = tabs.indexOf(currentFilter)
+
+    TabRow(
+        selectedTabIndex = selectedIndex,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        tabs.forEach { filter ->
+            val count = getFilterCount(filter)
+            Tab(
+                selected = filter == currentFilter,
+                onClick = { onFilterChange(filter) },
+                text = {
+                    Text(
+                        text = if (count > 0) {
+                            "${filter.displayName} ($count)"
+                        } else {
+                            filter.displayName
+                        }
+                    )
+                }
+            )
+        }
+    }
+}
+
+/**
+ * Empty state when no torrents match the filter.
+ */
+@Composable
+private fun EmptyState(
+    currentFilter: TorrentFilter,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Text(
+                text = when (currentFilter) {
+                    TorrentFilter.ALL -> "No torrents yet"
+                    TorrentFilter.QUEUED -> "No active torrents"
+                    TorrentFilter.FINISHED -> "No completed torrents"
+                },
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = when (currentFilter) {
+                    TorrentFilter.ALL -> "Tap + to add a magnet link"
+                    TorrentFilter.QUEUED -> "Downloading torrents will appear here"
+                    TorrentFilter.FINISHED -> "Completed torrents will appear here"
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+// =============================================================================
+// Previews
+// =============================================================================
+
+@Preview(showBackground = true)
+@Composable
+private fun EmptyStatePreview() {
+    JSTorrentTheme {
+        EmptyState(currentFilter = TorrentFilter.ALL)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoadingContentPreview() {
+    JSTorrentTheme {
+        LoadingContent()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ErrorContentPreview() {
+    JSTorrentTheme {
+        ErrorContent(message = "Failed to initialize engine")
+    }
+}


### PR DESCRIPTION
- Add TorrentListScreen with filter tabs (All/Queued/Finished)
- Add AddTorrentDialog bottom sheet for magnet links
- Integrate TorrentListViewModel with TorrentListScreen
- Add overflow menu with Pause All/Resume All options
- Add FAB for adding torrents
- Refactor NativeStandaloneActivity to use new screen components
- Add displayName property to TorrentFilter enum
- Add Compose UI tests for TorrentListScreen and AddTorrentDialog